### PR TITLE
Command based Improvements

### DIFF
--- a/.idea/runConfigurations/DesktopLauncher.xml
+++ b/.idea/runConfigurations/DesktopLauncher.xml
@@ -10,6 +10,10 @@
         <option name="PATTERN" value="com.dacubeking.autobuilder.gui.desktop.*" />
         <option name="ENABLED" value="true" />
       </pattern>
+      <pattern>
+        <option name="PATTERN" value="com.dacubeking.autobuilder.gui.*" />
+        <option name="ENABLED" value="true" />
+      </pattern>
     </extension>
     <method v="2">
       <option name="Make" enabled="true" />

--- a/core/src/main/com/dacubeking/autobuilder/gui/scripting/RobotCodeData.java
+++ b/core/src/main/com/dacubeking/autobuilder/gui/scripting/RobotCodeData.java
@@ -31,23 +31,184 @@ public class RobotCodeData {
 
     static {
         inferableTypesVerification = new Hashtable<>();
-        inferableTypesVerification.put(int.class.getName(), s -> s.matches("[0-9]+"));
-        inferableTypesVerification.put(double.class.getName(), s -> s.matches("[0-9]+\\.?[0-9]*"));
-        inferableTypesVerification.put(float.class.getName(), s -> s.matches("[0-9]+\\.?[0-9]*"));
-        inferableTypesVerification.put(long.class.getName(), s -> s.matches("[0-9]+"));
-        inferableTypesVerification.put(short.class.getName(), s -> s.matches("[0-9]+"));
-        inferableTypesVerification.put(byte.class.getName(), s -> s.matches("[0-9]+"));
-        inferableTypesVerification.put(char.class.getName(), s -> s.matches("[a-zA-Z]+"));
-        inferableTypesVerification.put(boolean.class.getName(), s -> s.matches("true|false"));
+        inferableTypesVerification.put(int.class.getName(), s -> {
+            if (!s.matches("^-?[0-9]+$")) {
+                return false;
+            }
+            try {
+                Integer.parseInt(s);
+            } catch (NumberFormatException e) {
+                return false;
+            }
+
+            return true;
+        });
+
+        inferableTypesVerification.put(double.class.getName(), s -> {
+            if (!s.matches("^[+-]?(\\d+([.]\\d*)?([eE][+-]?\\d+)?|[.]\\d+([eE][+-]?\\d+)?)$")) {
+                return false;
+            }
+            try {
+                Double.parseDouble(s);
+            } catch (NumberFormatException e) {
+                return false;
+            }
+
+            return true;
+        });
+
+        inferableTypesVerification.put(float.class.getName(), s -> {
+            if (!s.matches("^[+-]?(\\d+([.]\\d*)?([eE][+-]?\\d+)?|[.]\\d+([eE][+-]?\\d+)?)$")) {
+                return false;
+            }
+            try {
+                Float.parseFloat(s);
+            } catch (NumberFormatException e) {
+                return false;
+            }
+
+            return true;
+        });
+
+        inferableTypesVerification.put(long.class.getName(), s -> {
+            if (!s.matches("^-?[0-9]+$")) {
+                return false;
+            }
+            try {
+                Long.parseLong(s);
+            } catch (NumberFormatException e) {
+                return false;
+            }
+
+            return true;
+        });
+
+        inferableTypesVerification.put(short.class.getName(), s -> {
+            if (!s.matches("^-?[0-9]+$")) {
+                return false;
+            }
+            try {
+                Short.parseShort(s);
+            } catch (NumberFormatException e) {
+                return false;
+            }
+
+            return true;
+        });
+
+        inferableTypesVerification.put(byte.class.getName(), s -> {
+            if (!s.matches("^-?[0-9]+$")) {
+                return false;
+            }
+            try {
+                Byte.parseByte(s);
+            } catch (NumberFormatException e) {
+                return false;
+            }
+
+            return true;
+        });
+
+        inferableTypesVerification.put(byte.class.getName(), s -> {
+            if (!s.matches("^-?[0-9]+$")) {
+                return false;
+            }
+            try {
+                Byte.parseByte(s);
+            } catch (NumberFormatException e) {
+                return false;
+            }
+
+            return true;
+        });
+
+        inferableTypesVerification.put(char.class.getName(), s -> s.matches("^.$"));
+
+        inferableTypesVerification.put(boolean.class.getName(), s -> s.matches("^(?i)(true|false)$"));
+
         inferableTypesVerification.put(String.class.getName(), s -> true);
-        inferableTypesVerification.put(Integer.class.getName(), s -> s.matches("[0-9]+"));
-        inferableTypesVerification.put(Double.class.getName(), s -> s.matches("[0-9]+\\.?[0-9]*"));
-        inferableTypesVerification.put(Float.class.getName(), s -> s.matches("[0-9]+\\.?[0-9]*"));
-        inferableTypesVerification.put(Long.class.getName(), s -> s.matches("[0-9]+"));
-        inferableTypesVerification.put(Short.class.getName(), s -> s.matches("[0-9]+"));
-        inferableTypesVerification.put(Byte.class.getName(), s -> s.matches("[0-9]+"));
-        inferableTypesVerification.put(Character.class.getName(), s -> s.matches("[a-zA-Z]+"));
-        inferableTypesVerification.put(Boolean.class.getName(), s -> s.matches("true|false"));
+
+        inferableTypesVerification.put(Integer.class.getName(), s -> {
+            if (!s.matches("^-?[0-9]+$")) {
+                return false;
+            }
+            try {
+                Integer.parseInt(s);
+            } catch (NumberFormatException e) {
+                return false;
+            }
+
+            return true;
+        });
+
+        inferableTypesVerification.put(Double.class.getName(), s -> {
+            if (!s.matches("^[+-]?(\\d+([.]\\d*)?([eE][+-]?\\d+)?|[.]\\d+([eE][+-]?\\d+)?)$")) {
+                return false;
+            }
+            try {
+                Double.parseDouble(s);
+            } catch (NumberFormatException e) {
+                return false;
+            }
+
+            return true;
+        });
+
+        inferableTypesVerification.put(Float.class.getName(), s -> {
+            if (!s.matches("^[+-]?(\\d+([.]\\d*)?([eE][+-]?\\d+)?|[.]\\d+([eE][+-]?\\d+)?)$")) {
+                return false;
+            }
+            try {
+                Float.parseFloat(s);
+            } catch (NumberFormatException e) {
+                return false;
+            }
+
+            return true;
+        });
+
+        inferableTypesVerification.put(Long.class.getName(), s -> {
+            if (!s.matches("^-?[0-9]+$")) {
+                return false;
+            }
+            try {
+                Long.parseLong(s);
+            } catch (NumberFormatException e) {
+                return false;
+            }
+
+            return true;
+        });
+
+        inferableTypesVerification.put(Short.class.getName(), s -> {
+            if (!s.matches("^-?[0-9]+$")) {
+                return false;
+            }
+            try {
+                Short.parseShort(s);
+            } catch (NumberFormatException e) {
+                return false;
+            }
+
+            return true;
+        });
+
+        inferableTypesVerification.put(Byte.class.getName(), s -> {
+            if (!s.matches("^-?[0-9]+$")) {
+                return false;
+            }
+            try {
+                Byte.parseByte(s);
+            } catch (NumberFormatException e) {
+                return false;
+            }
+
+            return true;
+        });
+
+        inferableTypesVerification.put(Character.class.getName(), s -> s.matches("^.$"));
+
+        inferableTypesVerification.put(Boolean.class.getName(), s -> s.matches("^(?i)(true|false)$"));
     }
 
 

--- a/core/src/main/com/dacubeking/autobuilder/gui/scripting/RobotCodeData.java
+++ b/core/src/main/com/dacubeking/autobuilder/gui/scripting/RobotCodeData.java
@@ -12,6 +12,7 @@ import com.dacubeking.autobuilder.gui.scripting.reflection.ReflectionMethodData;
 import com.dacubeking.autobuilder.gui.scripting.sendable.SendableCommand;
 import com.dacubeking.autobuilder.gui.scripting.util.LintingPos;
 import com.dacubeking.autobuilder.gui.scripting.util.StringIndex;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
@@ -27,188 +28,63 @@ import static com.dacubeking.autobuilder.gui.scripting.util.StringIndex.splitWit
 
 public class RobotCodeData {
 
-    public static Map<String, Function<String, Boolean>> inferableTypesVerification;
+    public static final @NotNull Map<String, Function<@NotNull String, @NotNull Boolean>> inferableTypesVerification;
 
     static {
+        final Pattern intPattern = Pattern.compile("^-?[0-9]+$");
+        final Pattern decimalPattern =
+                Pattern.compile("^[+-]?(\\d+([.]\\d*)?([eE][+-]?\\d+)?|[.]\\d+([eE][+-]?\\d+)?)$");
+
+        final Function<String, Boolean> isInt = s -> checkNumberParseable(s, intPattern, Integer::parseInt);
+        final Function<String, Boolean> isDouble = s -> checkNumberParseable(s, decimalPattern, Double::parseDouble);
+        final Function<String, Boolean> isFloat = s -> checkNumberParseable(s, decimalPattern, Float::parseFloat);
+        final Function<String, Boolean> isLong = s -> checkNumberParseable(s, intPattern, Long::parseLong);
+        final Function<String, Boolean> isShort = s -> checkNumberParseable(s, intPattern, Short::parseShort);
+        final Function<String, Boolean> isByte = s -> checkNumberParseable(s, intPattern, Byte::parseByte);
+        final Function<String, Boolean> isChar = s -> s.length() == 1;
+        final Function<String, Boolean> isBoolean = s -> s.equalsIgnoreCase("true") || s.equalsIgnoreCase("false");
+
+
         inferableTypesVerification = new Hashtable<>();
-        inferableTypesVerification.put(int.class.getName(), s -> {
-            if (!s.matches("^-?[0-9]+$")) {
-                return false;
-            }
-            try {
-                Integer.parseInt(s);
-            } catch (NumberFormatException e) {
-                return false;
-            }
-
-            return true;
-        });
-
-        inferableTypesVerification.put(double.class.getName(), s -> {
-            if (!s.matches("^[+-]?(\\d+([.]\\d*)?([eE][+-]?\\d+)?|[.]\\d+([eE][+-]?\\d+)?)$")) {
-                return false;
-            }
-            try {
-                Double.parseDouble(s);
-            } catch (NumberFormatException e) {
-                return false;
-            }
-
-            return true;
-        });
-
-        inferableTypesVerification.put(float.class.getName(), s -> {
-            if (!s.matches("^[+-]?(\\d+([.]\\d*)?([eE][+-]?\\d+)?|[.]\\d+([eE][+-]?\\d+)?)$")) {
-                return false;
-            }
-            try {
-                Float.parseFloat(s);
-            } catch (NumberFormatException e) {
-                return false;
-            }
-
-            return true;
-        });
-
-        inferableTypesVerification.put(long.class.getName(), s -> {
-            if (!s.matches("^-?[0-9]+$")) {
-                return false;
-            }
-            try {
-                Long.parseLong(s);
-            } catch (NumberFormatException e) {
-                return false;
-            }
-
-            return true;
-        });
-
-        inferableTypesVerification.put(short.class.getName(), s -> {
-            if (!s.matches("^-?[0-9]+$")) {
-                return false;
-            }
-            try {
-                Short.parseShort(s);
-            } catch (NumberFormatException e) {
-                return false;
-            }
-
-            return true;
-        });
-
-        inferableTypesVerification.put(byte.class.getName(), s -> {
-            if (!s.matches("^-?[0-9]+$")) {
-                return false;
-            }
-            try {
-                Byte.parseByte(s);
-            } catch (NumberFormatException e) {
-                return false;
-            }
-
-            return true;
-        });
-
-        inferableTypesVerification.put(byte.class.getName(), s -> {
-            if (!s.matches("^-?[0-9]+$")) {
-                return false;
-            }
-            try {
-                Byte.parseByte(s);
-            } catch (NumberFormatException e) {
-                return false;
-            }
-
-            return true;
-        });
-
-        inferableTypesVerification.put(char.class.getName(), s -> s.matches("^.$"));
-
-        inferableTypesVerification.put(boolean.class.getName(), s -> s.matches("^(?i)(true|false)$"));
+        inferableTypesVerification.put(int.class.getName(), isInt);
+        inferableTypesVerification.put(double.class.getName(), isDouble);
+        inferableTypesVerification.put(float.class.getName(), isFloat);
+        inferableTypesVerification.put(long.class.getName(), isLong);
+        inferableTypesVerification.put(short.class.getName(), isShort);
+        inferableTypesVerification.put(byte.class.getName(), isByte);
+        inferableTypesVerification.put(char.class.getName(), isChar);
+        inferableTypesVerification.put(boolean.class.getName(), isBoolean);
 
         inferableTypesVerification.put(String.class.getName(), s -> true);
+        inferableTypesVerification.put(Integer.class.getName(), isInt);
+        inferableTypesVerification.put(Double.class.getName(), isDouble);
+        inferableTypesVerification.put(Float.class.getName(), isFloat);
+        inferableTypesVerification.put(Long.class.getName(), isLong);
+        inferableTypesVerification.put(Short.class.getName(), isShort);
+        inferableTypesVerification.put(Byte.class.getName(), isByte);
+        inferableTypesVerification.put(Character.class.getName(), isChar);
+        inferableTypesVerification.put(Boolean.class.getName(), isBoolean);
+    }
 
-        inferableTypesVerification.put(Integer.class.getName(), s -> {
-            if (!s.matches("^-?[0-9]+$")) {
-                return false;
-            }
-            try {
-                Integer.parseInt(s);
-            } catch (NumberFormatException e) {
-                return false;
-            }
-
-            return true;
-        });
-
-        inferableTypesVerification.put(Double.class.getName(), s -> {
-            if (!s.matches("^[+-]?(\\d+([.]\\d*)?([eE][+-]?\\d+)?|[.]\\d+([eE][+-]?\\d+)?)$")) {
-                return false;
-            }
-            try {
-                Double.parseDouble(s);
-            } catch (NumberFormatException e) {
-                return false;
-            }
-
-            return true;
-        });
-
-        inferableTypesVerification.put(Float.class.getName(), s -> {
-            if (!s.matches("^[+-]?(\\d+([.]\\d*)?([eE][+-]?\\d+)?|[.]\\d+([eE][+-]?\\d+)?)$")) {
-                return false;
-            }
-            try {
-                Float.parseFloat(s);
-            } catch (NumberFormatException e) {
-                return false;
-            }
-
-            return true;
-        });
-
-        inferableTypesVerification.put(Long.class.getName(), s -> {
-            if (!s.matches("^-?[0-9]+$")) {
-                return false;
-            }
-            try {
-                Long.parseLong(s);
-            } catch (NumberFormatException e) {
-                return false;
-            }
-
-            return true;
-        });
-
-        inferableTypesVerification.put(Short.class.getName(), s -> {
-            if (!s.matches("^-?[0-9]+$")) {
-                return false;
-            }
-            try {
-                Short.parseShort(s);
-            } catch (NumberFormatException e) {
-                return false;
-            }
-
-            return true;
-        });
-
-        inferableTypesVerification.put(Byte.class.getName(), s -> {
-            if (!s.matches("^-?[0-9]+$")) {
-                return false;
-            }
-            try {
-                Byte.parseByte(s);
-            } catch (NumberFormatException e) {
-                return false;
-            }
-
-            return true;
-        });
-
-        inferableTypesVerification.put(Character.class.getName(), s -> s.matches("^.$"));
-
-        inferableTypesVerification.put(Boolean.class.getName(), s -> s.matches("^(?i)(true|false)$"));
+    /**
+     * Checks if a string is parseable as a number
+     *
+     * @param s             The string to check
+     * @param pattern       The pattern to check against
+     * @param parseFunction The function to parse the string with
+     * @return True if the string is parseable as a number
+     */
+    private static boolean checkNumberParseable(@NotNull String s, @NotNull Pattern pattern,
+                                                @NotNull Function<@NotNull String, ?> parseFunction) {
+        if (pattern.asMatchPredicate().test(s)) {
+            return false;
+        }
+        try {
+            parseFunction.apply(s);
+        } catch (NumberFormatException e) {
+            return false;
+        }
+        return true;
     }
 
 

--- a/core/src/main/com/dacubeking/autobuilder/gui/scripting/reflection/ReflectionClassData.java
+++ b/core/src/main/com/dacubeking/autobuilder/gui/scripting/reflection/ReflectionClassData.java
@@ -2,6 +2,7 @@ package com.dacubeking.autobuilder.gui.scripting.reflection;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -9,18 +10,26 @@ import java.util.Arrays;
 import java.util.Hashtable;
 
 public final class ReflectionClassData {
-    public final String fullName;
-    public final String[] fieldNames;
-    public final String[] fieldTypes;
-    public final ReflectionMethodData[] methods;
-    public final int modifiers;
-    public final boolean isEnum;
 
     public Hashtable<String, ArrayList<ReflectionMethodData>> methodMap = new Hashtable<>();
+    @JsonProperty
+    @NotNull
+    public final String fullName;
+    @JsonProperty public final String @NotNull [] fieldNames;
+    @JsonProperty public final String @NotNull [] fieldTypes;
+    @JsonProperty public final ReflectionMethodData @NotNull [] methods;
 
-    public ReflectionClassData(Class<?> clazz) {
+    @JsonProperty
+    private final @NotNull String superClass;
+
+    @JsonProperty public final String @NotNull [] interfaces;
+    @JsonProperty public final int modifiers;
+    @JsonProperty public final boolean isEnum;
+    @JsonProperty public final boolean isCommand;
+
+    public ReflectionClassData(@NotNull Class<?> clazz) {
         this.fullName = clazz.getName();
-        Method[] methods = clazz.getMethods();
+        Method[] methods = clazz.getDeclaredMethods();
         this.methods = new ReflectionMethodData[methods.length];
         for (int i = 0; i < methods.length; i++) {
             this.methods[i] = new ReflectionMethodData(methods[i]);
@@ -33,9 +42,31 @@ public final class ReflectionClassData {
             this.fieldTypes[i] = clazz.getDeclaredFields()[i].getType().getName();
         }
 
-        isEnum = clazz.isEnum();
+        this.superClass = clazz.getSuperclass().getName();
+        interfaces = Arrays.stream(clazz.getInterfaces()).map(Class::getName).toArray(String[]::new);
 
         modifiers = clazz.getModifiers();
+        this.isEnum = clazz.isEnum();
+
+        isCommand = isCommand(clazz);
+    }
+
+    private boolean isCommand(Class<?> clazz) {
+        if (clazz == null) {
+            return false;
+        }
+
+        if (clazz.getName().equals("edu.wpi.first.wpilibj2.command.Command")) {
+            return true;
+        }
+
+        for (Class<?> anInterface : clazz.getInterfaces()) {
+            if (isCommand(anInterface)) {
+                return true;
+            }
+        }
+
+        return isCommand(clazz.getSuperclass());
     }
 
     public void initMap() {
@@ -48,18 +79,24 @@ public final class ReflectionClassData {
     }
 
     @JsonCreator
-    public ReflectionClassData(@JsonProperty("fullName") String fullName,
-                               @JsonProperty("fieldNames") String[] fieldNames,
-                               @JsonProperty("fieldTypes") String[] fieldTypes,
-                               @JsonProperty("methods") ReflectionMethodData[] methods,
+    public ReflectionClassData(@JsonProperty("fullName") @NotNull String fullName,
+                               @JsonProperty("fieldNames") String @NotNull [] fieldNames,
+                               @JsonProperty("fieldTypes") String @NotNull [] fieldTypes,
+                               @JsonProperty("methods") ReflectionMethodData @NotNull [] methods,
+                               @JsonProperty("superClass") @NotNull String superClass,
+                               @JsonProperty("interfaces") String @NotNull [] interfaces,
                                @JsonProperty("modifiers") int modifiers,
-                               @JsonProperty("isEnum") boolean isEnum) {
+                               @JsonProperty("isEnum") boolean isEnum,
+                               @JsonProperty("isCommand") boolean isCommand) {
         this.fullName = fullName;
         this.fieldNames = fieldNames;
         this.fieldTypes = fieldTypes;
         this.methods = methods;
         this.modifiers = modifiers;
+        this.superClass = superClass;
+        this.interfaces = interfaces;
         this.isEnum = isEnum;
+        this.isCommand = isCommand;
     }
 
     @Override
@@ -69,6 +106,11 @@ public final class ReflectionClassData {
                 ", fieldNames=" + Arrays.toString(fieldNames) +
                 ", fieldTypes=" + Arrays.toString(fieldTypes) +
                 ", methods=" + Arrays.toString(methods) +
+                ", superClass='" + superClass + '\'' +
+                ", interfaces=" + Arrays.toString(interfaces) +
+                ", modifiers=" + modifiers +
+                ", isEnum=" + isEnum +
+                ", isCommand=" + isCommand +
                 '}';
     }
 }

--- a/core/src/main/com/dacubeking/autobuilder/gui/scripting/sendable/SendableCommand.java
+++ b/core/src/main/com/dacubeking/autobuilder/gui/scripting/sendable/SendableCommand.java
@@ -6,17 +6,27 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Arrays;
 
 public record SendableCommand(@JsonProperty("methodName") String methodName, @JsonProperty("args") String[] args,
-                              @JsonProperty("argTypes") String[] argTypes, @JsonProperty("reflection") boolean reflection) {
+                              @JsonProperty("argTypes") String[] argTypes, @JsonProperty("reflection") boolean reflection,
+                              @JsonProperty("command") boolean command) {
 
     @JsonCreator
     public SendableCommand(@JsonProperty("methodName") String methodName,
                            @JsonProperty("args") String[] args,
                            @JsonProperty("argTypes") String[] argTypes,
-                           @JsonProperty("reflection") boolean reflection) {
+                           @JsonProperty("reflection") boolean reflection,
+                           @JsonProperty("command") boolean command) {
         this.methodName = methodName;
         this.args = args;
         this.argTypes = argTypes;
         this.reflection = reflection;
+        this.command = command;
+    }
+
+    public SendableCommand(@JsonProperty("methodName") String methodName,
+                           @JsonProperty("args") String[] args,
+                           @JsonProperty("argTypes") String[] argTypes,
+                           @JsonProperty("reflection") boolean reflection) {
+        this(methodName, args, argTypes, reflection, false);
     }
 
     @Override

--- a/core/src/main/com/dacubeking/autobuilder/gui/scripting/util/StringIndex.java
+++ b/core/src/main/com/dacubeking/autobuilder/gui/scripting/util/StringIndex.java
@@ -21,6 +21,23 @@ public record StringIndex(int index, String string) {
         return stringIndices;
     }
 
+    public int length() {
+        return string.length();
+    }
+
+    public int getEndIndex() {
+        return index + string.length();
+    }
+
+    public StringIndex getSubStringIndex(int start, int end) {
+        return new StringIndex(index + start, string.substring(start, end));
+    }
+
+    public StringIndex getSubStringIndex(int start) {
+        return new StringIndex(index + start, string.substring(start));
+    }
+
+
     @Override
     public String toString() {
         return string;


### PR DESCRIPTION
This PR adds some special cases for classes that implement `Command`. Instead of having to call methods of the command class (`initialize`, `execute`, and `end`), the AutoBuilder will now recognize it as a Command and automatically execute the entire command when you just type the name of the class.

![image](https://user-images.githubusercontent.com/59785640/205425339-55c4ebbb-2893-4812-a530-18ea312f2b1e.png)

The GUI hasn't actually changed much to support this. All I've done is 1) made it so that the robot side tells the GUI which classes are wpi commands and 2) added some code to detect when the user has typed out a class that implements command so we can tag that `SendableCommand` as a `command` so it can be executed on the robot. 

One thing that may be a bit confusing is when `SendableCommand` (Note this `SendableCommand` is unrelated to the WPILib `Command`) is marked as a command, the `methodName` field stores the class name of the `Command` we want to execute instead of a method.

Here are the corresponding changes on the robot side: https://github.com/FRC3476/AutoBuilder-RobotSide/pull/3

I fixed a bunch of bugs I found while testing the code so that's why there are some other unrelated changes/

The important changes related to this PR are in the `SendableCommand` class. I also rewrote a bit of the other related code for discovering the correct method when people use the boxed types (ex `Integer` instead of `int`). And rewrote some of the error messages. 

The code is a bit messy since we need to take special care to run these methods on the main thread, as none of the commands are thread-safe. Right now, I'm just passing runnable that then gets run on a periodic function that's executed on the main thread. Is there a better way to do this?

I've done some testing in simulation and everything seems to be working right now!

