### PR TITLE
Shader trajectories

### DIFF
--- a/core/assets/shaders/trajectory.frag
+++ b/core/assets/shaders/trajectory.frag
@@ -6,9 +6,6 @@ precision mediump float;
 #endif
 
 varying LOWP vec4 v_color;
-varying vec2 v_texCoords;
-
-//uniform sampler2D u_texture;
 
 void main()
 {

--- a/core/assets/shaders/trajectory.frag
+++ b/core/assets/shaders/trajectory.frag
@@ -1,0 +1,16 @@
+#ifdef GL_ES
+#define LOWP lowp
+precision mediump float;
+#else
+#define LOWP
+#endif
+
+varying LOWP vec4 v_color;
+varying vec2 v_texCoords;
+
+//uniform sampler2D u_texture;
+
+void main()
+{
+    gl_FragColor = v_color;
+}

--- a/core/assets/shaders/trajectory.vert
+++ b/core/assets/shaders/trajectory.vert
@@ -12,13 +12,12 @@ attribute float a_speedPercent;
 uniform mat4 u_projTrans;
 uniform vec2 u_colorhv;
 
-
 varying vec4 v_color;
 
 void main()
 {
     vec3 _hsvColor = vec3(u_colorhv.x, a_speedPercent * 0.9 + 0.1, u_colorhv.y);
     v_color = vec4(hsv2rgb(_hsvColor), 0);
-    vec4 pos = vec4(a_position.xy, 0, 1);;
+    vec4 pos = vec4(a_position.xy, 0, 1);
     gl_Position =  u_projTrans * pos;
 }

--- a/core/assets/shaders/trajectory.vert
+++ b/core/assets/shaders/trajectory.vert
@@ -1,0 +1,24 @@
+// All components are in the range [0…1], including hue.
+vec3 hsv2rgb(vec3 c)
+{
+    vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+    vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
+    return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
+}
+
+attribute vec2 a_position;
+attribute float a_speedPercent;
+
+uniform mat4 u_projTrans;
+uniform vec2 u_colorhv;
+
+
+varying vec4 v_color;
+
+void main()
+{
+    vec3 _hsvColor = vec3(u_colorhv.x, a_speedPercent * 0.9 + 0.1, u_colorhv.y);
+    v_color = vec4(hsv2rgb(_hsvColor), 0);
+    vec4 pos = vec4(a_position.xy, 0, 1);;
+    gl_Position =  u_projTrans * pos;
+}

--- a/core/src/main/com/dacubeking/autobuilder/gui/AutoBuilder.java
+++ b/core/src/main/com/dacubeking/autobuilder/gui/AutoBuilder.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.ApplicationAdapter;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.Input;
+import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.*;
 import com.badlogic.gdx.graphics.Cursor.SystemCursor;
@@ -327,7 +328,7 @@ public final class AutoBuilder extends ApplicationAdapter {
         //batch.flush();
 
         //Draw all the paths
-        origin.draw(shapeRenderer, cam);
+        origin.draw(shapeRenderer);
 
         double pathTime = 0;
         for (AbstractGuiItem guiItem : pathGui.guiItems) {
@@ -619,5 +620,12 @@ public final class AutoBuilder extends ApplicationAdapter {
             undoHandler.clearUndoHistory();
         }
         undoHandler.forceCreateUndoState();
+    }
+
+
+    private final @NotNull AssetManager assetManager = new AssetManager();
+
+    public @NotNull AssetManager getAssetManager() {
+        return assetManager;
     }
 }

--- a/core/src/main/com/dacubeking/autobuilder/gui/pathing/MovablePointRenderer.java
+++ b/core/src/main/com/dacubeking/autobuilder/gui/pathing/MovablePointRenderer.java
@@ -12,8 +12,6 @@ import com.dacubeking.autobuilder.gui.events.movablepoint.PointMoveEvent;
 import com.dacubeking.autobuilder.gui.undo.UndoHandler;
 import org.jetbrains.annotations.NotNull;
 
-import static com.dacubeking.autobuilder.gui.AutoBuilder.POINT_SIZE;
-
 public class MovablePointRenderer extends PointRenderer {
 
 
@@ -45,7 +43,8 @@ public class MovablePointRenderer extends PointRenderer {
 
     public boolean update(@NotNull OrthographicCamera camera, @NotNull Vector3 mousePos, Vector3 mouseDiff) {
         if (Gdx.input.isButtonJustPressed(Input.Buttons.LEFT) || Gdx.input.isButtonJustPressed(Input.Buttons.RIGHT)) {
-            if (new Vector3(mousePos).sub(getRenderPos3()).len2() < Math.pow(Math.max(20 * camera.zoom, POINT_SIZE), 2)) {
+            if (new Vector3(mousePos).sub(getRenderPos3()).len2() <
+                    Math.pow(Math.max(20 * camera.zoom, AutoBuilder.getPointSize() * radius), 2)) {
                 if (Gdx.input.isButtonJustPressed(Input.Buttons.LEFT)) {
                     startPress.set(mousePos);
                     pressed = true;

--- a/core/src/main/com/dacubeking/autobuilder/gui/pathing/PointRenderer.java
+++ b/core/src/main/com/dacubeking/autobuilder/gui/pathing/PointRenderer.java
@@ -1,7 +1,6 @@
 package com.dacubeking.autobuilder.gui.pathing;
 
 import com.badlogic.gdx.graphics.Color;
-import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Vector3;
 import com.dacubeking.autobuilder.gui.AutoBuilder;
@@ -36,7 +35,7 @@ public class PointRenderer {
         this.y = y;
     }
 
-    public void draw(@NotNull ShapeDrawer shape, @NotNull OrthographicCamera camera) {
+    public void draw(@NotNull ShapeDrawer shape) {
         float pointScaleFactor = AutoBuilder.getConfig().getPointScaleFactor();
         shape.filledCircle(x * pointScaleFactor, y * pointScaleFactor, AutoBuilder.getPointSize(), color);
     }

--- a/core/src/main/com/dacubeking/autobuilder/gui/pathing/PointRenderer.java
+++ b/core/src/main/com/dacubeking/autobuilder/gui/pathing/PointRenderer.java
@@ -11,11 +11,17 @@ public class PointRenderer {
     protected float x;
     protected float y;
     protected Color color;
+    protected float radius;
 
-    public PointRenderer(float x, float y, Color color) {
+    public PointRenderer(float x, float y, Color color, float radius) {
         this.x = x;
         this.y = y;
         this.color = color;
+        this.radius = radius;
+    }
+
+    public PointRenderer(float x, float y, Color color) {
+        this(x, y, color, 1);
     }
 
     public PointRenderer(@NotNull Vector2 pos, Color color) {
@@ -23,6 +29,14 @@ public class PointRenderer {
         this.y = pos.y;
         this.color = color;
     }
+
+    public PointRenderer(@NotNull Vector2 pos, Color color, float radius) {
+        this.x = pos.x;
+        this.y = pos.y;
+        this.color = color;
+        this.radius = radius;
+    }
+
 
     public PointRenderer(@NotNull Vector3 pos, Color color) {
         this.x = pos.x;
@@ -37,7 +51,7 @@ public class PointRenderer {
 
     public void draw(@NotNull ShapeDrawer shape) {
         float pointScaleFactor = AutoBuilder.getConfig().getPointScaleFactor();
-        shape.filledCircle(x * pointScaleFactor, y * pointScaleFactor, AutoBuilder.getPointSize(), color);
+        shape.filledCircle(x * pointScaleFactor, y * pointScaleFactor, AutoBuilder.getPointSize() * radius, color);
     }
 
 

--- a/core/src/main/com/dacubeking/autobuilder/gui/pathing/TrajectoryPathRenderer.java
+++ b/core/src/main/com/dacubeking/autobuilder/gui/pathing/TrajectoryPathRenderer.java
@@ -281,7 +281,7 @@ public class TrajectoryPathRenderer extends PathRenderer implements MovablePoint
 
             if (i == selectionPointIndex) {
                 if (highlightPoint == null) {
-                    highlightPoint = new PointRenderer(pointRenderer.getPos2(), Color.WHITE);
+                    highlightPoint = new PointRenderer(pointRenderer.getPos2(), Color.WHITE, 1.4f);
                 } else {
                     highlightPoint.setPosition(pointRenderer.getPos2());
                 }

--- a/core/src/main/com/dacubeking/autobuilder/gui/util/shaders/ShaderLoader.java
+++ b/core/src/main/com/dacubeking/autobuilder/gui/util/shaders/ShaderLoader.java
@@ -1,0 +1,24 @@
+package com.dacubeking.autobuilder.gui.util.shaders;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.assets.loaders.ShaderProgramLoader;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import com.dacubeking.autobuilder.gui.AutoBuilder;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+public final class ShaderLoader {
+
+    private ShaderLoader() {
+    }
+
+    private static final @NotNull ShaderProgramLoader.ShaderProgramParameter defaultShaderParameter =
+            new ShaderProgramLoader.ShaderProgramParameter();
+
+    @Contract("_ -> new")
+    public static @NotNull ShaderProgram loadShader(@NotNull String name) {
+        var assetManager = AutoBuilder.getInstance().getAssetManager();
+        return new ShaderProgram(Gdx.files.internal("shaders/" + name + ".vert"),
+                Gdx.files.internal("shaders/" + name + ".frag"));
+    }
+}


### PR DESCRIPTION
use shaders to make smooth out colors in paths

this implementation also uses less bandwidth between the GPU and CPU as it's vertex format is more compact